### PR TITLE
Fix 6.12 kernel compilation

### DIFF
--- a/driver/vocalfusion-soundcard.c
+++ b/driver/vocalfusion-soundcard.c
@@ -20,7 +20,7 @@
 
 // Forward declarations for the driver's probe and remove functions
 static int vocalfusion_soundcard_probe(struct platform_device *pdev);
-static int vocalfusion_soundcard_remove(struct platform_device *pdev);
+static void vocalfusion_soundcard_remove(struct platform_device *pdev);
 
 /*
  * Probe function - Initializes the sound card device
@@ -83,14 +83,13 @@ static int vocalfusion_soundcard_probe(struct platform_device *pdev) {
  * Remove function - Cleans up the device on removal
  * Disables and unprepares the clock
  */
-static int vocalfusion_soundcard_remove(struct platform_device *pdev) {
+static void vocalfusion_soundcard_remove(struct platform_device *pdev) {
     struct clk *mclk = devm_clk_get(&pdev->dev, NULL); // Re-obtain the clock
     if (!IS_ERR(mclk)) {
         clk_disable_unprepare(mclk); // Disable the clock
     }
 
     pr_info("VocalFusion soundcard module unloaded\n");
-    return 0;
 }
 
 // Device compatibility table


### PR DESCRIPTION
```
(ovos) goldyfruit@mark2:~/VocalFusionDriver/driver $ sudo make -j4 KDIR=/lib/modules/6.12.20+rpt-rpi-v8/build all
make -C /lib/modules/6.12.20+rpt-rpi-v8/build M=/home/goldyfruit/VocalFusionDriver/driver modules
make[1]: Entering directory '/usr/src/linux-headers-6.12.20+rpt-rpi-v8'
  CC [M]  /home/goldyfruit/VocalFusionDriver/driver/vocalfusion-soundcard.o
  MODPOST /home/goldyfruit/VocalFusionDriver/driver/Module.symvers
  CC [M]  /home/goldyfruit/VocalFusionDriver/driver/vocalfusion-soundcard.mod.o
  CC [M]  /home/goldyfruit/VocalFusionDriver/driver/.module-common.o
  LD [M]  /home/goldyfruit/VocalFusionDriver/driver/vocalfusion-soundcard.ko
make[1]: Leaving directory '/usr/src/linux-headers-6.12.20+rpt-rpi-v8'
```
```
(ovos) goldyfruit@mark2:~/VocalFusionDriver/driver $ uname -a
Linux mark2 6.12.20+rpt-rpi-v8 #1 SMP PREEMPT Debian 1:6.12.20-1+rpt1~bpo12+1 (2025-03-19) aarch64 GNU/Linux
```
```
(ovos) goldyfruit@mark2:~/VocalFusionDriver/driver $ lsmod | grep vocal
vocalfusion_soundcard    12288  0
```
```
(ovos) goldyfruit@mark2:~/VocalFusionDriver/driver $ modinfo vocalfusion_soundcard
filename:       /lib/modules/6.12.20+rpt-rpi-v8/vocalfusion-soundcard.ko
alias:          platform:vocalfusion-soundcard
license:        GPL v2
author:         OpenVoiceOS
description:    XMOS VocalFusion I2S Driver
srcversion:     0EB0AE57C6CDDC6258B9624
alias:          of:N*T*Cvocalfusion-soundcardC*
alias:          of:N*T*Cvocalfusion-soundcard
depends:        
name:           vocalfusion_soundcard
vermagic:       6.12.20+rpt-rpi-v8 SMP preempt mod_unload modversions aarch64
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the internal device removal workflow to streamline completion handling while maintaining the current functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->